### PR TITLE
fix(install): Fix `arch` command not found

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-case "$(arch)" in
+case "$(uname -m)" in
 x86_64) SUFFIX="x86_64" ;;
 aarch64) SUFFIX="aarch64" ;;
 armv6l) SUFFIX="armv6" ;;


### PR DESCRIPTION
`arch` command/variable is not installed/defined by default in some distributions (Linux Arch for example), so the install script should use `uname -m` to get CPU architecture.